### PR TITLE
added tox to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 __pycache__/
 .cache
+.tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Falcon-Oauth
 
-Oauth wrapper around [oauthlib](https://github.com/idan/oauthlib/) for Falcon.
+Oauth wrapper around [oauthlib](https://github.com/oauthlib/oauthlib/) for Falcon.
 
 Based on https://github.com/lepture/flask-oauthlib/.
 

--- a/falcon_oauth/provider/oauth2/validator.py
+++ b/falcon_oauth/provider/oauth2/validator.py
@@ -12,7 +12,7 @@ log = logging.getLogger('falcon_oauth')
 class OAuthValidator(RequestValidator):
     """Subclass of Request Validator.
 
-    See https://github.com/idan/oauthlib/blob/master/oauthlib/oauth2/rfc6749/request_validator.py  # noqa
+    See https://github.com/oauthlib/oauthlib/blob/master/oauthlib/oauth2/rfc6749/request_validator.py  # noqa
     and https://oauthlib.readthedocs.org/en/latest/oauth2/validator.html
 
     :param clientgetter: a function to get client object

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest==2.8.2
 python-dateutil
+peewee==3.5.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest==2.8.2
 python-dateutil
 peewee==3.5.2
+pytest-falcon

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'Topic :: Scientific/Engineering :: GIS',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
     ],
     keywords='falcon oauth',
     test_suite='tests',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     keywords='falcon oauth',
+    test_suite='tests',
     packages=find_packages(exclude=['tests']),
     install_requires=install_requires,
     extras_require={'test': ['pytest'], 'docs': 'mkdocs'},

--- a/tests/provider/oauth2/base.py
+++ b/tests/provider/oauth2/base.py
@@ -12,7 +12,7 @@ db = peewee.SqliteDatabase(':memory:')
 
 
 class DateTimeField(peewee.DateTimeField):
-    # Sqlite does not parse offset in datetime…
+    # Sqlite does not parse offset in datetime
 
     def python_value(self, value):
         if value:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
-envlist = py27,py36
+envlist = py36
 
 [testenv]
 deps=
     -rrequirements-dev.txt
     -rrequirements.txt
-commands=python -m pytest
-
-[testenv:py27]
-deps=unittest2
-     {[testenv]deps}
+commands=py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27,py36
+
+[testenv]
+deps=
+    -rrequirements-dev.txt
+    -rrequirements.txt
+commands=python -m pytest
+
+[testenv:py27]
+deps=unittest2
+     {[testenv]deps}


### PR DESCRIPTION
Hi,
I don't know if this project is still used, or if any users are interested, but I give it a try to see if tests were working as expected. 
As I didn't found any automatic building tools, I am proposing `tox`. It seems `pytest` was used to run tests, but, not sure of the syntax here.

Both python27 and python36 are failing at the moment.

`tox -e py27`:
```
E   ConftestImportFailure: (local('/Users/doomsday/eds/oauthlib/falcon-oauth/tests/provider/oauth2/conftest.py'), (<type 'exceptions.ImportError'>, ImportError('cannot import name timezone',), <traceback object at 0x105ba9440>))
```

`tox -e py36`:
```
  def test_simple_get(client):
        fixture 'client' not found
        available fixtures: pytestconfig, capfd, capsys, tmpdir, tmpdir_factory, monkeypatch, recwarn, record_xml_property, cache, app, clientmodel, token, user
        use 'py.test --fixtures [testpath]' for help on them.
```

@yohanboniface ,
Dunno if you are still working on this or if you have any time :-)


